### PR TITLE
Compare language extension with the file extension

### DIFF
--- a/src/presence/presence.ts
+++ b/src/presence/presence.ts
@@ -34,13 +34,14 @@ export const getPresence = (startTimeStamp: number | Date, workspace?: string, f
 	}
 
 	const lang = languages.find((lang) => {
+		const lastExtension = ext[ext.length - 1];
 		if (lang.fileName && fileName === fileNameForLanguage(lang)) {
 			return lang;
 		}
 		if (lang.fileName && isAliasedExtensionForFile(lang, fileName)) {
 			return lang;
 		}
-		if (!lang.fileName && lang.extension === ext[0]) {
+		if (!lang.fileName && lang.extension === lastExtension) {
 			return lang;
 		}
 		if (!lang.fileName && lang.extension === ext.join(".")) {


### PR DESCRIPTION
I was editing the *exchanges.service.ts* file in NeoVim, and I noticed that the icon was not of TypeScript, so I analyzed your code and realized that you were comparing the first extension of the file `(service)`, then I changed it to compare it with the last extension of the file `(ts)`.